### PR TITLE
Fix URL and typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
               <a class="nav-link" href="#sponsor">SPONSOR</a>
             </li>
             <li class="nav-item pr-3">
-              <a class="nav-link" href="#upcoming">UPCOMING MEETUP</a>
+              <a class="nav-link" href="#upcoming">UPCOMING MEETUPS</a>
             </li>
             <li class="nav-item pr-3">
               <a class="nav-link" target="_blank" href="https://github.com/nodejsnigeria/welcome">JOIN</a>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
               <a class="nav-link" href="#upcoming">UPCOMING MEETUP</a>
             </li>
             <li class="nav-item pr-3">
-              <a class="nav-link" target="_blank" href="https://github.com/welcome">JOIN</a>
+              <a class="nav-link" target="_blank" href="https://github.com/nodejsnigeria/welcome">JOIN</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
The URL to the welcome repo was wrong, and there was also a typo in the menu.